### PR TITLE
Add support for user i2c devices

### DIFF
--- a/roboquest_addons/MLX90614.py
+++ b/roboquest_addons/MLX90614.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python3
+
+from time import sleep
+from smbus2 import SMBus
+from mlx90614 import MLX90614
+import RPi.GPIO as GPIO
+
+I2C_ENABLE_PIN = 17
+
+GPIO.setwarnings(False)
+GPIO.setmode(GPIO.BCM)
+GPIO.setup(I2C_ENABLE_PIN, GPIO.OUT)
+GPIO.output(I2C_ENABLE_PIN, GPIO.HIGH)
+
+bus = SMBus(6)
+sensor = MLX90614(bus, address=0x5a)
+
+for count in range(1, 1001):
+    print(
+        f'Ambient: {sensor.get_amb_temp():0.2f}'
+        f', Object: {sensor.get_obj_temp():0.2f}'
+    )
+    sleep(0.5)
+
+bus.close()
+GPIO.output(I2C_ENABLE_PIN, GPIO.LOW)
+GPIO.cleanup()

--- a/roboquest_addons/MLX90614_node.py
+++ b/roboquest_addons/MLX90614_node.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+"""Example temperature publisher node.
+
+A ROS node to publish temperature readings from an MLX90614 I2C
+temperature sensor.
+"""
+
+import RPi.GPIO as GPIO
+
+from mlx90614 import MLX90614
+
+import rclpy
+from rclpy.node import Node
+
+from smbus2 import SMBus
+
+from std_msgs.msg import Float32
+
+I2C_ENABLE_PIN = 17
+TIMER_PERIOD_S = 5
+MILLIS_PER_S = 1000
+
+
+class MLX90614Publisher(Node):
+    """Publisher.
+
+    The class handling the setup and operation of the MLX90614.
+    """
+
+    def __init__(self):
+        """Create the publisher and the timer."""
+        super().__init__('mlx90614_publisher')
+        self._publisher_ = self.create_publisher(Float32, 'temperature', 1)
+        self.timer = self.create_timer(TIMER_PERIOD_S, self._timer_callback)
+        self.i = 0
+        self._bus = SMBus(6)
+        self._mlx90614 = MLX90614(self._bus, address=0x5a)
+
+        GPIO.setwarnings(False)
+        GPIO.setmode(GPIO.BCM)
+        GPIO.setup(I2C_ENABLE_PIN, GPIO.OUT)
+        GPIO.output(I2C_ENABLE_PIN, GPIO.HIGH)
+
+    def _timer_callback(self):
+        msg = Float32()
+        msg.data = self._mlx90614.get_amb_temp()
+        self._publisher_.publish(msg)
+
+    def shutdown(self):
+        """Shutdown the connections."""
+        GPIO.output(I2C_ENABLE_PIN, GPIO.LOW)
+        GPIO.close()
+        self._bus.close()
+
+
+def main(args=None):
+    """Initialize the ROS node.
+
+    Initialize the node and instantiate the ExamplePublisher class.
+    """
+    rclpy.init(args=args)
+
+    mlx90614_publisher = MLX90614Publisher()
+
+    rclpy.spin(mlx90614_publisher)
+
+    mlx90614_publisher.destroy_node()
+
+    rclpy.shutdown()
+
+
+if __name__ == '__main__':
+    main()

--- a/roboquest_addons/VL53L0Xsimple.py
+++ b/roboquest_addons/VL53L0Xsimple.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+# MIT License
+# 
+# Copyright (c) 2017 John Bryan Moore
+# 
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+# 
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+# 
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+import time
+import VL53L0X
+import RPi.GPIO as GPIO
+
+MOTOR_ENABLE_PIN = 17
+
+GPIO.setwarnings(False)
+GPIO.setmode(GPIO.BCM)
+GPIO.setup(MOTOR_ENABLE_PIN, GPIO.OUT)
+GPIO.output(MOTOR_ENABLE_PIN, GPIO.HIGH)
+
+# Create a VL53L0X object
+tof = VL53L0X.VL53L0X(i2c_bus=6, i2c_address=0x29)
+# I2C Address can change before tof.open()
+# tof.change_address(0x32)
+tof.open()
+# Start ranging
+tof.start_ranging(VL53L0X.Vl53l0xAccuracyMode.BETTER)
+
+timing = tof.get_timing()
+if timing < 20000:
+    timing = 20000
+print("Timing %d ms" % (timing/1000))
+
+for count in range(1, 1001):
+    distance = tof.get_distance()
+    if distance > 0:
+        print("%d mm, %d cm, %d" % (distance, (distance/10), count))
+
+    time.sleep(timing/1000000.00)
+
+tof.stop_ranging()
+tof.close()
+
+GPIO.output(MOTOR_ENABLE_PIN, GPIO.LOW)
+GPIO.cleanup()

--- a/scripts/dstart.sh
+++ b/scripts/dstart.sh
@@ -7,13 +7,14 @@
 IMAGE=$1
 NAME=rq_addons
 
-printf "Starting %s on %s\n" "$IMAGE" "$DOCKER_HOST"
+printf "Starting %s on %s\n" "$IMAGE" "$(docker context show)"
 
 docker run -d --rm \
         --privileged \
         --network host \
         --ipc host \
         --env "ROS_DOMAIN_ID=72" \
+        --device /dev/i2c-6:/dev/i2c-6 \
         --device /dev/ttyUSB0:/dev/ttyUSB0 \
         -v /dev/shm:/dev/shm \
         -v /var/run/dbus:/var/run/dbus \


### PR DESCRIPTION
Requires [rq_core v24](https://github.com/billmania/roboquest_core/issues?q=label%3Av24+)

Includes example scripts and ROS nodes for the VL53L0X range finder and MLX90614 temperature sensor. These scripts are part of the "addons" docker image, intended to be built separately from rq_core and rq_ui and deployed as a third container on the Roboquest platform.

See [rq_core wiki](https://github.com/billmania/roboquest_core/wiki/Adding-I2C-devices) for more details.