### PR TITLE
Initial demo of recognizing an APRILtag and moving the robot

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,6 +27,8 @@ install(DIRECTORY config
 
 ament_python_install_package(${PROJECT_NAME})
 install(PROGRAMS
+        scripts/navigator.py
+        scripts/static_robot_tf2_broadcaster.py
         DESTINATION lib/${PROJECT_NAME}
 )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,42 @@
+cmake_minimum_required(VERSION 3.5)
+project(roboquest_addons)
+
+# Default to C99
+if(NOT CMAKE_C_STANDARD)
+  set(CMAKE_C_STANDARD 99)
+endif()
+
+# Default to C++14
+if(NOT CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 14)
+endif()
+
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wall -Wextra -Wpedantic)
+endif()
+
+find_package(ament_cmake REQUIRED)
+find_package(ament_cmake_python REQUIRED)
+find_package(rclpy REQUIRED)
+
+install(DIRECTORY launch
+        DESTINATION share/${PROJECT_NAME})
+
+install(DIRECTORY config
+        DESTINATION share/${PROJECT_NAME})
+
+ament_python_install_package(${PROJECT_NAME})
+install(PROGRAMS
+        DESTINATION lib/${PROJECT_NAME}
+)
+
+if(BUILD_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+  ament_lint_auto_find_test_dependencies()
+endif()
+
+find_package(rosidl_default_generators REQUIRED)
+
+ament_export_dependencies(rosidl_default_runtime)
+
+ament_package()

--- a/config/tags_36h11.yaml
+++ b/config/tags_36h11.yaml
@@ -4,6 +4,7 @@
         family: 36h11           # tag family name
         size: 0.173             # tag edge size in meter
         max_hamming: 0          # maximum allowed hamming distance
+        pose_estimation_method: pnp  # options are ('pnp', 'homography')
         detector:
             threads: 1          # number of threads
             decimate: 2.0       # decimate resolution for quad detection

--- a/launch/autonomy_demo.launch.py
+++ b/launch/autonomy_demo.launch.py
@@ -1,0 +1,57 @@
+"""Roboquest Autonomy Demo launch file."""
+import os
+
+from ament_index_python.packages import get_package_share_directory
+
+from launch import LaunchDescription
+
+from launch_ros.actions import ComposableNodeContainer
+from launch_ros.actions import Node
+from launch_ros.descriptions import ComposableNode
+
+
+def generate_launch_description():
+    """Define an RPLiDAR and april_tag launch description."""
+    april_params = os.path.join(
+        get_package_share_directory('roboquest_addons'),
+        'config',
+        'tags_36h11.yaml'
+    )
+
+    return LaunchDescription([
+        Node(
+            package='rplidar_ros',
+            executable='rplidar_node',
+            name='rplidar_node',
+            parameters=[{'channel_type': 'serial',
+                         'serial_port': '/dev/ttyUSB0',
+                         'serial_baudrate': 460800,
+                         'frame_id': 'laser',
+                         'inverted': False,
+                         'angle_compensate': True,
+                         'scan_mode': 'Standard'}],
+            output='screen'
+        ),
+        ComposableNodeContainer(
+            name='apriltag_container',
+            namespace='',
+            package='rclcpp_components',
+            executable='component_container',
+            composable_node_descriptions=[
+                ComposableNode(
+                    package='apriltag_ros',
+                    plugin='AprilTagNode',
+                    name='apriltag',
+                    remappings=[
+                        ('/apriltag/image_rect', '/rq_camera_node0/image_raw'),
+                        ('/apriltag/camera_info',
+                         '/rq_camera_node0/camera_info')
+                    ],
+                    parameters=[
+                        april_params
+                    ]
+                )
+            ],
+            output='both'
+        )
+    ])

--- a/launch/autonomy_demo.launch.py
+++ b/launch/autonomy_demo.launch.py
@@ -23,6 +23,7 @@ def generate_launch_description():
             package='rplidar_ros',
             executable='rplidar_node',
             name='rplidar_node',
+            namespace='',
             parameters=[{'channel_type': 'serial',
                          'serial_port': '/dev/ttyUSB0',
                          'serial_baudrate': 460800,
@@ -30,22 +31,22 @@ def generate_launch_description():
                          'inverted': False,
                          'angle_compensate': True,
                          'scan_mode': 'Standard'}],
-            output='screen'
+            output='both'
         ),
         ComposableNodeContainer(
-            name='apriltag_container',
-            namespace='',
             package='rclcpp_components',
             executable='component_container',
+            name='apriltag_container',
+            namespace='',
             composable_node_descriptions=[
                 ComposableNode(
                     package='apriltag_ros',
                     plugin='AprilTagNode',
                     name='apriltag',
+                    namespace='',
                     remappings=[
-                        ('/apriltag/image_rect', '/rq_camera_node0/image_raw'),
-                        ('/apriltag/camera_info',
-                         '/rq_camera_node0/camera_info')
+                        ('/image_rect', '/rq_camera_node0/image_raw'),
+                        ('/camera_info', '/rq_camera_node0/camera_info')
                     ],
                     parameters=[
                         april_params

--- a/launch/autonomy_demo.launch.py
+++ b/launch/autonomy_demo.launch.py
@@ -19,6 +19,29 @@ def generate_launch_description():
     )
 
     return LaunchDescription([
+#        Node(
+#            package='tf2_ros',
+#            executable='static_transform_publisher',
+#            arguments=[
+#                '--x',
+#                '0',
+#                '--y',
+#                '0.01',
+#                '--z',
+#                '0',
+#                '--frame-id',
+#                'base_link',
+#                '--child-frame-id',
+#                'arducam'
+#            ]
+#        ),
+        Node(
+            package='roboquest_addons',
+            executable='navigator.py',
+            name='navigator',
+            namespace='',
+            output='both'
+        ),
         Node(
             package='rplidar_ros',
             executable='rplidar_node',

--- a/package.xml
+++ b/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>roboquest_addons</name>
-  <version>0.1.0</version>
+  <version>0.4.0</version>
   <description>RoboQuest components outside the base functionality</description>
   <maintainer email="bill@manialabs.us">Bill Mania</maintainer>
   <license>Proprietary</license>
@@ -13,14 +13,17 @@
   <test_depend>python3-pytest</test_depend>
 
   <exec_depend>ros2launch</exec_depend>
+  <exec_depend>geometry_msgs</exec_depend>
+  <exec_depend>python3-numpy</exec_depend>
+  <exec_depend>rclpy</exec_depend>
+  <exec_depend>tf2_ros_py</exec_depend>
+  <exec_depend>tf2_ros</exec_depend>
+  <exec_depend>std_msgs</exec_depend>
+  <exec_depend>apriltag_msgs</exec_depend>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
   <buildtool_depend>ament_cmake_python</buildtool_depend>
 
-  <depend>rclpy</depend>
-  <depend>std_msgs</depend>
-  <depend>geometry_msgs</depend>
-  <depend>diagnostic_msgs</depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/package.xml
+++ b/package.xml
@@ -14,7 +14,15 @@
 
   <exec_depend>ros2launch</exec_depend>
 
+  <buildtool_depend>ament_cmake</buildtool_depend>
+  <buildtool_depend>ament_cmake_python</buildtool_depend>
+
+  <depend>rclpy</depend>
+  <depend>std_msgs</depend>
+  <depend>geometry_msgs</depend>
+  <depend>diagnostic_msgs</depend>
+
   <export>
-    <build_type>ament_python</build_type>
+    <build_type>ament_cmake</build_type>
   </export>
 </package>

--- a/roboquest_addons/navigator.py
+++ b/roboquest_addons/navigator.py
@@ -1,0 +1,74 @@
+"""Follow a path using APRIL tags as the waypoints."""
+from apriltag_msgs.msg import AprilTagDetectionArray
+
+import rclpy
+import rclpy.logging
+from rclpy.node import Node
+
+from tf2_msgs.msg import TFMessage
+
+
+class Navigation(Node):
+    """Guide the robot toward a goal.
+
+    Consume APRIL tag detections and TF to move toward
+    an APRIL tag.
+    """
+
+    def __init__(self):
+        """Create the two subscriptions and publishers.
+
+        Subscribe to APRIL tag detection messages and TF
+        transform messages. Publish TwistStamped to the cmd_vel
+        topic.
+        """
+        super().__init__('navigation')
+        self._log = self.get_logger()
+        self._detection_sub = self.create_subscription(
+            AprilTagDetectionArray,
+            'detections',
+            self._detections_cb,
+            1
+        )
+        self._tf_sub = self.create_subscription(
+            TFMessage,
+            'tf',
+            self._tf_cb,
+            1
+        )
+        self._log.info(
+            'Navigator started'
+        )
+
+    def _detections_cb(self, msg):
+        """Handle a received Detections message."""
+        if msg.detections:
+            for detection in msg.detections:
+                self._log.debug(
+                    f'{detection.family}:{detection.id} ->'
+                    f' ({detection.centre.x:.0f},{detection.centre.y:.0f})'
+                )
+
+    def _tf_cb(self, msg):
+        """Handle a received TF message."""
+        if msg.transforms:
+            self._log.debug(
+                'Received tf'
+            )
+
+
+def main(args=None):
+    """Run the main loop."""
+    rclpy.init(args=args)
+    rclpy.logging.set_logger_level(
+        'navigator',
+        rclpy.logging.LoggingSeverity.DEBUG
+    )
+
+    navigation = Navigation()
+    rclpy.spin(navigation)
+    rclpy.shutdown()
+
+
+if __name__ == '__main__':
+    main()

--- a/roboquest_addons/navigator.py
+++ b/roboquest_addons/navigator.py
@@ -1,11 +1,21 @@
+#!/usr/bin/env python3
+
 """Follow a path using APRIL tags as the waypoints."""
 from apriltag_msgs.msg import AprilTagDetectionArray
+
+from geometry_msgs.msg import TwistStamped
 
 import rclpy
 import rclpy.logging
 from rclpy.node import Node
 
+from rq_msgs.srv import Control
+
 from tf2_msgs.msg import TFMessage
+
+CLOSE_ENOUGH = 10
+CAMERA_WIDTH = 640
+CAMERA_HEIGHT = 480
 
 
 class Navigation(Node):
@@ -24,6 +34,15 @@ class Navigation(Node):
         """
         super().__init__('navigation')
         self._log = self.get_logger()
+
+        self._twist = TwistStamped()
+        self._control_request = Control.Request()
+
+        self._camera = {
+            'x_center': int(CAMERA_WIDTH / 2),
+            'y_center': int(CAMERA_HEIGHT / 2)
+        }
+
         self._detection_sub = self.create_subscription(
             AprilTagDetectionArray,
             'detections',
@@ -36,23 +55,84 @@ class Navigation(Node):
             self._tf_cb,
             1
         )
+        self._cmd_vel_pub = self.create_publisher(
+            TwistStamped,
+            'cmd_vel',
+            1
+        )
+        self._control_client = self.create_client(
+            Control,
+            'control_hat'
+        )
+        self._log.info(
+            'Connecting to control_hat service'
+        )
+        while not self._control_client.wait_for_service(timeout_sec=5.0):
+            self._log.warn(
+                'control_hat service not available'
+            )
+        self._control_request.set_motors = 'ON'
+        self._log.info(
+                'Requesting motors ON async'
+        )
+        self._control_response = None
+        self._control_future = self._control_client.call_async(
+            self._control_request
+        )
+        self._log.info(
+            'Requested motors ON'
+        )
+
+        self._cmd_vel_timer = self.create_timer(
+            0.5,
+            self._move
+        )
+        self._log.info(
+            'cmd_vel timer started'
+        )
         self._log.info(
             'Navigator started'
+        )
+
+    def _move(self):
+        """Move the robot."""
+        if not self._control_future.done():
+            self._log.info(
+                'motors not yet ON'
+            )
+            return
+
+        self._cmd_vel_pub.publish(self._twist)
+        self._log.info(
+            '_move():'
+            f' {self._twist.twist.angular.z}'
         )
 
     def _detections_cb(self, msg):
         """Handle a received Detections message."""
         if msg.detections:
-            for detection in msg.detections:
-                self._log.debug(
-                    f'{detection.family}:{detection.id} ->'
-                    f' ({detection.centre.x:.0f},{detection.centre.y:.0f})'
-                )
+            x_diff = msg.detections[0].centre.x - self._camera['x_center']
+            if abs(x_diff) <= CLOSE_ENOUGH:
+                turn_toward = 'AHEAD'
+                self._twist.twist.angular.z = 0.0
+            elif x_diff < 0:
+                turn_toward = 'TURN_LEFT'
+                self._twist.twist.angular.z = 0.2
+            else:
+                turn_toward = 'TURN_RIGHT'
+                self._twist.twist.angular.z = -0.2
+
+            self._log.info(
+                f'{turn_toward}'
+            )
+        else:
+            turn_toward = 'LOST'
+            self._twist.twist.angular.z = 0.0
 
     def _tf_cb(self, msg):
         """Handle a received TF message."""
         if msg.transforms:
-            self._log.debug(
+            self._log.info(
                 'Received tf'
             )
 
@@ -67,6 +147,8 @@ def main(args=None):
 
     navigation = Navigation()
     rclpy.spin(navigation)
+    navigation._control_request.set_motors = 'ON'
+    navigation._control_client.call_async(navigation._control_request)
     rclpy.shutdown()
 
 

--- a/roboquest_addons/navigator.py
+++ b/roboquest_addons/navigator.py
@@ -17,6 +17,9 @@ CLOSE_ENOUGH = 10
 CAMERA_WIDTH = 640
 CAMERA_HEIGHT = 480
 
+TURN_SPEED = 40.0
+MOVE_SPEED = 40.0
+
 
 class Navigation(Node):
     """Guide the robot toward a goal.
@@ -136,10 +139,10 @@ class Navigation(Node):
                 self._twist.twist.angular.z = 0.0
             elif x_diff < 0:
                 turn_toward = 'TURN_LEFT'
-                self._twist.twist.angular.z = 0.2
+                self._twist.twist.angular.z = -TURN_SPEED
             else:
                 turn_toward = 'TURN_RIGHT'
-                self._twist.twist.angular.z = -0.2
+                self._twist.twist.angular.z = TURN_SPEED
 
             self._log.info(
                 f'{turn_toward}'

--- a/scripts/autonomy_demo.sh
+++ b/scripts/autonomy_demo.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+cd /usr/src/ros2ws || exit 1
+source /opt/ros/humble/setup.bash
+
+source install/setup.bash
+
+ros2 launch roboquest_addons autonomy_demo.launch.py

--- a/scripts/dstart.sh
+++ b/scripts/dstart.sh
@@ -9,7 +9,7 @@ NAME=rq_addons
 
 printf "Starting %s on %s\n" "$IMAGE" "$(docker context show)"
 
-docker run -d --rm \
+docker run -it --rm \
         --privileged \
         --network host \
         --ipc host \

--- a/scripts/dstart.sh
+++ b/scripts/dstart.sh
@@ -5,11 +5,11 @@
 #
 
 IMAGE=$1
-NAME=rq_addons
+NAME=$1
 
 printf "Starting %s on %s\n" "$IMAGE" "$(docker context show)"
 
-docker run -it --rm \
+docker run -d --rm \
         --privileged \
         --network host \
         --ipc host \

--- a/scripts/static_robot_tf2_broadcaster.py
+++ b/scripts/static_robot_tf2_broadcaster.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+"""Publish a static transform for the robot."""
+import math
+import sys
+
+from geometry_msgs.msg import TransformStamped
+
+import numpy as np
+
+import rclpy
+from rclpy.node import Node
+
+from tf2_ros.static_transform_broadcaster import StaticTransformBroadcaster
+
+
+def quaternion_from_euler(ai, aj, ak):
+    """
+    Convert Euler angles.
+
+    A utility function to conver from Euler angles to a quaternion.
+    """
+    ai /= 2.0
+    aj /= 2.0
+    ak /= 2.0
+    ci = math.cos(ai)
+    si = math.sin(ai)
+    cj = math.cos(aj)
+    sj = math.sin(aj)
+    ck = math.cos(ak)
+    sk = math.sin(ak)
+    cc = ci*ck
+    cs = ci*sk
+    sc = si*ck
+    ss = si*sk
+
+    q = np.empty((4, ))
+    q[0] = cj*sc - sj*cs
+    q[1] = cj*ss + sj*cc
+    q[2] = cj*cs - sj*sc
+    q[3] = cj*cc + sj*ss
+
+    return q
+
+
+class StaticFramePublisher(Node):
+    """
+    Publish transforms that never change.
+
+    Publish transforms from `world` to a static robot frame.
+    The transforms are only published once at startup and are constant for all
+    time.
+    """
+
+    def __init__(self, transformation):
+        """Initialize the class."""
+        super().__init__(
+            'static_robot_tf2_broadcaster',
+            enable_logger_service=True
+        )
+
+        self.tf_static_broadcaster = StaticTransformBroadcaster(self)
+
+        self.make_transforms(transformation)
+
+    def make_transforms(self, transformation):
+        """Make the transforms."""
+        t = TransformStamped()
+
+        t.header.stamp = self.get_clock().now().to_msg()
+        t.header.frame_id = 'world'
+        t.child_frame_id = transformation[1]
+
+        t.transform.translation.x = float(transformation[2])
+        t.transform.translation.y = float(transformation[3])
+        t.transform.translation.z = float(transformation[4])
+        quat = quaternion_from_euler(
+            float(transformation[5]),
+            float(transformation[6]),
+            float(transformation[7])
+        )
+        t.transform.rotation.x = quat[0]
+        t.transform.rotation.y = quat[1]
+        t.transform.rotation.z = quat[2]
+        t.transform.rotation.w = quat[3]
+
+        self.tf_static_broadcaster.sendTransform(t)
+
+
+def main():
+    """Run the main logic."""
+    logger = rclpy.logging.get_logger('logger')
+
+    if len(sys.argv) != 8:
+        logger.error(
+            'Usage: \n'
+            ' ros2 run roboquest_addons static_robot_tf2_broadcaster'
+            ' child_frame_name x y z roll pitch yaw'
+        )
+        sys.exit(1)
+
+    if sys.argv[1] == 'world':
+        logger.error('Static robot frame cannot be "world"')
+        sys.exit(2)
+
+    rclpy.init()
+    node = StaticFramePublisher(sys.argv)
+    try:
+        rclpy.spin(node)
+
+    except KeyboardInterrupt:
+        pass
+
+    rclpy.shutdown()
+
+
+if __name__ == '__main__':
+    main()

--- a/setup.py
+++ b/setup.py
@@ -21,4 +21,10 @@ setup(
     maintainer_email='bill@manialabs.us',
     description='RoboQuest components outside the base functionality',
     license='Proprietary',
+    entry_points={
+        'console_scripts': [
+            'navigator = roboquest_addons.navigator:main',
+            'static_robot_tf2_broadcaster = roboquest_addons.static_robot_tf2_broadcaster:main'
+        ]
+    },
 )

--- a/setup.py
+++ b/setup.py
@@ -6,13 +6,13 @@ package_name = 'roboquest_addons'
 
 setup(
     name=package_name,
-    version='0.1.0',
+    version='0.4.0',
     packages=find_packages(exclude=['test']),
     data_files=[
         ('share/ament_index/resource_index/packages',
             ['resource/' + package_name]),
         ('share/' + package_name, ['package.xml']),
-        (os.path.join('share', package_name, 'launch'), glob('launch/*.launch.yml')),
+        (os.path.join('share', package_name, 'launch'), glob('launch/*.launch.py')),
         (os.path.join('share', package_name, 'config'), glob('config/*.yaml'))
     ],
     install_requires=['setuptools'],


### PR DESCRIPTION
Created a new docker image definition, using Dockerfile.roboquest_autonomy_demo, to start an RPLiDAR node and an apriltag node in a single Python launch file. Both nodes start in a container separate from rq_core and rq_ui. The RPLiDAR node publishes the point cloud and the apriltag node consumes images from the existing camera frame topic and publishes detections.

This is only a demonstration of the basic idea. It subscribes to the detections topic and publishes to the cmd_vel topic. It subscribes to the tf topic, but doesn't do anything with the messages.
