### PR TITLE
Restart containerd.service after modifying its config file

### DIFF
--- a/rpi-image-gen/rq-lidar-april/config/rq-lidar-april.yaml
+++ b/rpi-image-gen/rq-lidar-april/config/rq-lidar-april.yaml
@@ -19,7 +19,7 @@ image:
 
 #
 # Debian packages to be automatically installed into the root filesystem.
-# None of the image customization process depends on these packages.
+# Some of the image customization process depends on some of these packages.
 #
 packages:
   - vim

--- a/rpi-image-gen/rq-lidar-april/image/rq-partitions/bdebstrap/customize30-configure
+++ b/rpi-image-gen/rq-lidar-april/image/rq-partitions/bdebstrap/customize30-configure
@@ -29,12 +29,13 @@ chroot ${CHROOT} /usr/sbin/iw reg set US
 printf "customize30-configure: WiFi country set\n"
 
 #
-# Install docker and adjust containerd
+# Adjust containerd and install docker
 #
+chroot ${CHROOT} /usr/bin/install -d --owner=root --group root --mode=0700 /opt/containerd/data
+
 chroot ${CHROOT} /usr/sbin/groupadd docker
 chroot ${CHROOT} /usr/bin/install -d --owner=root --group docker --mode=0750 /opt/docker
 chroot ${CHROOT} ln -s /opt/docker /var/lib/docker
-chroot ${CHROOT} /usr/bin/install -d --owner=root --group root --mode=0700 /opt/containerd/data
 chroot ${CHROOT} /usr/sbin/usermod -aG docker roboquest
 chroot ${CHROOT} /usr/bin/install -d --owner=root --group root --mode=0755 /etc/systemd/system/docker.service.d
 
@@ -48,7 +49,7 @@ chmod 0755 ${CHROOT}/opt/docker/install-docker.sh
 
 cat << EOF > ${CHROOT}/etc/systemd/system/docker-install.service
 [Unit]
-Description=Install docker and create ros_logs
+Description=Install docker, adjust containerd.io, and create ros_logs
 After=network.target
 ConditionPathExists=!/opt/docker/docker-install-done
 
@@ -60,6 +61,7 @@ ExecStart=/opt/docker/install-docker.sh
 ExecStart=/usr/bin/docker volume create ros_logs
 ExecStart=sed -i -e 's|^#root = "/var/lib/containerd"$|root = "/opt/containerd/data"|' /etc/containerd/config.toml
 ExecStartPost=/usr/bin/touch /opt/docker/docker-install-done
+ExecStartPost=/bin/systemctl restart containerd.service
 RemainAfterExit=yes
 
 [Install]


### PR DESCRIPTION
In order for the configuration change to containerd, the service containerd.service is restarted after first boot. This is done so a docker image could be built immediately after first boot and have it be placed in the new image directory docker-install.service.

https://github.com/billmania/roboquest_addons/issues/20